### PR TITLE
fix: h5页面请求url为相对路径时，url的拼接问题。

### DIFF
--- a/KKJSBridge/KKJSBridge/Modules/Ajax/KKJSBridgeModuleXMLHttpRequestDispatcher.m
+++ b/KKJSBridge/KKJSBridge/Modules/Ajax/KKJSBridgeModuleXMLHttpRequestDispatcher.m
@@ -73,7 +73,10 @@
                     NSString *tmpPort = port.length > 0 ? [NSString stringWithFormat:@":%@", port] : @"";
                     url = [NSString stringWithFormat:@"%@//%@%@%@",scheme, host, tmpPort, tmpPath];
                 } else { // 处理 【./】 【../】 【../../】和前面没有前缀的情况
-                    url = [[href stringByAppendingPathComponent:url] stringByStandardizingPath];
+                    NSURL *newUrl = [NSURL URLWithString:url relativeToURL:[NSURL URLWithString:href]];
+                    NSURLComponents *urlComponents = [[NSURLComponents alloc] initWithURL:newUrl resolvingAgainstBaseURL:YES];
+                    urlComponents.query = nil;
+                    url = urlComponents.string;
                 }
             }
         } else {


### PR DESCRIPTION
作者您好，h5页面请求url为相对路径时，测试发现地址拼接处的代码有误：

```java
 url = [[href stringByAppendingPathComponent:url] stringByStandardizingPath];
```
实际并不会按照期望的规则进行拼接，建议改成NSURL的拼接方式：

```java
NSURL *newUrl = [NSURL URLWithString:url relativeToURL:[NSURL URLWithString:href]];

 NSURLComponents *urlComponents = [[NSURLComponents alloc] initWithURL:newUrl resolvingAgainstBaseURL:YES];
// 清除h5页面的参数
urlComponents.query = nil;
url = urlComponents.string;
```
