### PR TITLE
feature: bridge 支持同步的 JS-Native 交互

### DIFF
--- a/KKJSBridge/KKJSBridge/Dispatcher/KKJSBridgeMessage.h
+++ b/KKJSBridge/KKJSBridge/Dispatcher/KKJSBridgeMessage.h
@@ -12,7 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, KKJSBridgeMessageType) {
     KKJSBridgeMessageTypeCallback,
-    KKJSBridgeMessageTypeEvent
+    KKJSBridgeMessageTypeEvent,
+    KKJSBridgeMessageTypeSyncCall,
 };
 
 /**
@@ -27,6 +28,9 @@ typedef NS_ENUM(NSInteger, KKJSBridgeMessageType) {
 @property (nonatomic, copy, nullable) NSString *module;
 @property (nonatomic, copy, nullable) NSString *method;
 @property (nonatomic, copy, nullable) NSString *callbackId;
+
+/// 同步 JS call 的回调
+@property (nonatomic, copy, nullable) void (^syncCallback)(NSDictionary *responseData);
 
 #pragma mark - event 相关
 @property (nonatomic, copy, nullable) NSString *eventName;

--- a/KKJSBridge/KKJSBridge/Dispatcher/KKJSBridgeMessageDispatcher.m
+++ b/KKJSBridge/KKJSBridge/Dispatcher/KKJSBridgeMessageDispatcher.m
@@ -140,6 +140,8 @@ typedef void (^KKJSBridgeMessageCallback)(NSDictionary *responseData);
                     [KKJSBridgeLogger log:@"Send out" module:moduleName method:methodName data:responseData];
                     [self dispatchMessageResponse:callbackMessageResponse];
                 };
+            } else if (message.messageType == KKJSBridgeMessageTypeSyncCall) {
+                callback = message.syncCallback;
             }
             
             [KKJSBridgeLogger log:@"Receive" module:moduleName method:methodName data:params];

--- a/KKJSBridge/KKJSBridge/JS/KKJSBridge.js
+++ b/KKJSBridge/KKJSBridge/JS/KKJSBridge.js
@@ -653,6 +653,23 @@
                 this.eventCallbackCache = {};
             }
             /**
+             * 同步调用 Native 方法
+             * @param module 模块
+             * @param method 方法
+             * @param data 数据
+             */
+            KKJSBridge.prototype.syncCall = function (module, method, data) {
+              var message = {
+                  module: module || 'default',
+                  method: method,
+                  data: data
+              };
+
+              const obj = JSON.stringify(message);
+              var response = window.prompt("KKJSBridgeSyncCall", obj);
+              return response ? JSON.parse(response) : null;
+            };
+            /**
              * 调用 Natvie 方法
              * @param module 模块
              * @param method 方法

--- a/KKJSBridge/KKJSBridge/KKJSBridgeEngine.h
+++ b/KKJSBridge/KKJSBridge/KKJSBridgeEngine.h
@@ -13,6 +13,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class KKJSBridgeMessageDispatcher;
+
 /**
  JSBridge 引擎，统一管理 webView 桥接，模块注册，JSBridge 配置和分发事件
  */
@@ -20,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak, readonly) WKWebView *webView; // 与桥接器对应的 webView
 @property (nonatomic, strong, readonly) KKJSBridgeModuleRegister *moduleRegister; // 模块注册者
+@property (nonatomic, strong, readonly) KKJSBridgeMessageDispatcher *dispatcher; // 消息分发者
 @property (nonatomic, strong, readonly) KKJSBridgeConfig *config; // jsbridge 配置
 @property (nonatomic, assign, getter=isBridgeReady) BOOL bridgeReady; // jsbridge 是否已经 ready
 

--- a/KKJSBridge/KKJSBridge/KKJSBridgeEngine.m
+++ b/KKJSBridge/KKJSBridge/KKJSBridgeEngine.m
@@ -13,6 +13,16 @@
 #import "KKJSBridgeModuleCookie.h"
 #import "KKJSBridgeWeakScriptMessageDelegate.h"
 
+// 欺骗编译器，实际上我们使用的 KKWebView
+@interface WKWebView (KKJSBridgeEngine)
+@property (nonatomic, weak) KKJSBridgeEngine *engine;
+@end
+
+@implementation WKWebView (KKJSBridgeEngine)
+- (KKJSBridgeEngine *)engine { return nil; }
+- (void)setEngine:(KKJSBridgeEngine *)engine {}
+@end
+
 static NSString * const KKJSBridgeMessageName = @"KKJSBridgeMessage";
 
 @interface KKJSBridgeEngine()<WKScriptMessageHandler>
@@ -36,6 +46,7 @@ static NSString * const KKJSBridgeMessageName = @"KKJSBridgeMessage";
 
 + (instancetype)bridgeForWebView:(WKWebView *)webView {
     KKJSBridgeEngine *bridge = [[self alloc] initWithWebView:webView];
+    webView.engine = bridge;
     return bridge;
 }
 

--- a/KKJSBridge/KKJSBridge/View/KKWebView.h
+++ b/KKJSBridge/KKJSBridge/View/KKWebView.h
@@ -11,6 +11,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class KKJSBridgeEngine;
+
 @protocol KKWebViewDelegate <WKNavigationDelegate>
 
 @end
@@ -50,6 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
  
  */
 @interface KKWebView : WKWebView
+
+@property (nonatomic, weak) KKJSBridgeEngine *engine;
 
 @end
 

--- a/KKJSBridge/KKJSBridge/View/KKWebView.m
+++ b/KKJSBridge/KKJSBridge/View/KKWebView.m
@@ -10,6 +10,9 @@
 #import "KKWebViewPool.h"
 #import "WKWebView+KKWebViewReusable.h"
 #import "KKWebViewCookieManager.h"
+#import "KKJSBridgeEngine.h"
+#import "KKJSBridgeMessage.h"
+#import "KKJSBridgeMessageDispatcher.h"
 
 @interface KKWebView() <WKNavigationDelegate, WKUIDelegate>
 
@@ -193,6 +196,12 @@
 
 // webView 中的输入框
 - (void)webView:(WKWebView *)webView runJavaScriptTextInputPanelWithPrompt:(NSString *)prompt defaultText:(nullable NSString *)defaultText initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSString * _Nullable result))completionHandler {
+    
+    // 如果是约定好的 KKJSBridgeSyncCall，则按照同步消息派发，并回调 completionHandler
+    if ([self webView:webView ifSyncCallWithPrompt:prompt defaultText:defaultText initiatedByFrame:frame completionHandler:completionHandler]) {
+        return;
+    }
+    
     if (![self canShowPanelWithWebView:webView]) {
         completionHandler(nil);
         return;
@@ -252,6 +261,49 @@
     while (viewController.presentedViewController)
         viewController = viewController.presentedViewController;
     return viewController;
+}
+
+- (BOOL)webView:(WKWebView *)webView ifSyncCallWithPrompt:(NSString *)prompt defaultText:(nullable NSString *)defaultText initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSString * _Nullable result))completionHandler
+{
+    if (![prompt isEqualToString:@"KKJSBridgeSyncCall"]) {
+        return NO;
+    }
+    
+    if (nil == defaultText
+        || nil == _engine) {
+        completionHandler(nil);
+        return YES;
+    }
+    
+    NSData *jsonData = [defaultText dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *error;
+    NSDictionary *userInfo = [NSJSONSerialization JSONObjectWithData:jsonData options:kNilOptions error:&error];
+    if (nil != error || nil == userInfo) {
+        completionHandler(nil);
+        return YES;
+    }
+    
+    KKJSBridgeMessage *messageInstance = [_engine.dispatcher convertMessageFromMessageJson:userInfo];
+    messageInstance.messageType = KKJSBridgeMessageTypeSyncCall;
+    messageInstance.syncCallback = ^(NSDictionary * _Nonnull responseData) {
+        if (nil == responseData || 0 == responseData.count) {
+            completionHandler(nil);
+            return;
+        }
+        
+        NSError *error;
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:responseData options:kNilOptions error:&error];
+        if (nil != error || nil == jsonData) {
+            completionHandler(nil);
+            return;
+        }
+        
+        NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+        completionHandler(jsonString);
+    };
+    [_engine.dispatcher dispatchCallbackMessage:messageInstance];
+    
+    return YES;
 }
 
 #pragma mark - 当前 WebView 加载完时，先预加载下一个 WebView 实例，以备下个页面可以直接使用

--- a/KKJSBridgeDemo/KKJSBridgeDemo/Software/Server/jsbridgeTest.html
+++ b/KKJSBridgeDemo/KKJSBridgeDemo/Software/Server/jsbridgeTest.html
@@ -23,6 +23,7 @@
     <button onclick="invokeModuleDefaultFunctionToTransferMsg()">调用默认模块功能把消息并转发给C模块</button>
     <button onclick="invokeModuleAFunction()">调用模块A功能给a+1并返回结果</button>
 	<button onclick="invokeModuleBFunction()">调用模块B功能获取VC的标题</button>
+    <button onclick="invokeModuleBSyncFunction();">同步调用模块B功能获取VC的标题</button>
 </body>
 <script src="https://cdn.bootcss.com/eruda/1.5.2/eruda.min.js"></script>
 <script>eruda.init();</script>
@@ -63,6 +64,11 @@
         window.KKJSBridge.call('b', 'callToGetVCTitle', {}, function(res) {
             console.log('receive vc title：', res.title);
         });
+    }
+
+    function invokeModuleBSyncFunction() {
+        const res = window.KKJSBridge.syncCall('b', 'callToGetVCTitle', {});
+        alert('title: ' + res.title);
     }
 </script>
 </html>


### PR DESCRIPTION
通过原生的 `window.webkit.messageHandlers` 来 `postMessage` 的方式是异步的，有时候 JS 端也需要同步交互。

在此次 PR 中借助 `webView:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:` 的特性，实现了同步交互。

用法如下：

```objective-c
function syncCallFunction() {
    const parameters = {}; // or {'some': 'some value or empty is Okay'}
    const result = window.KKJSBridge.syncCall('module', 'method', parameters);
    alert('value: ' + result.value);
}
```