### PR TITLE
feat: 重构部分代码并增加 sendBeacon 的 hook

### DIFF
--- a/KKJSBridge/TS/src/hook/KKJSBridgeSendBeaconHook.ts
+++ b/KKJSBridge/TS/src/hook/KKJSBridgeSendBeaconHook.ts
@@ -1,0 +1,33 @@
+import {_KKJSBridgeXHR} from './KKJSBridgeAjaxProtocolHook';
+
+export class _KKJSBridgeSendBeaconHook {
+    public static setupHook() {
+        if (typeof window.navigator.sendBeacon === 'function') {
+            const originalBeaconImpl = window.navigator.sendBeacon;
+            window.navigator.sendBeacon = function (url: string, data?: BodyInit): boolean {
+                if (!data) {
+                    return originalBeaconImpl(url, data);
+                }
+
+                const requestId = _KKJSBridgeXHR.generateXHRRequestId();
+                const requestUrl = _KKJSBridgeXHR.generateNewUrlWithRequestId(url, requestId);
+                const requestRaw: KK.AJAXBodyCacheRequest = {
+                    requestId: requestId,
+                    requestHref: location.href,
+                    requestUrl: url,
+                    bodyType: 'String',
+                    value: null
+                };
+
+                _KKJSBridgeXHR.resolveRequestBody(data).then(request => {
+                    _KKJSBridgeXHR.sendBodyToNativeForCache('AJAX', window.navigator, originalBeaconImpl, [requestUrl, data], {
+                        ...requestRaw,
+                        ...request
+                    });
+                });
+
+                return true;
+            };
+        }
+    }
+}

--- a/KKJSBridge/TS/src/index.ts
+++ b/KKJSBridge/TS/src/index.ts
@@ -5,6 +5,7 @@ import { KKJSBridge } from "./bridge/KKJSBridge"
 import { _KKJSBridgeFormData } from "./hook/KKJSBridgeFormDataHook"
 import { _KKJSBridgeCOOKIE } from "./hook/KKJSBridgeCookieHook"
 import { _KKJSBridgeXHR } from "./hook/KKJSBridgeAjaxProtocolHook"
+import { _KKJSBridgeSendBeaconHook } from "./hook/KKJSBridgeSendBeaconHook"
 
 var init = function() {
   if (window.KKJSBridge) {
@@ -75,6 +76,9 @@ var init = function() {
 
   // 安装 cookie hook
   _KKJSBridgeCOOKIE.setupHook();
+
+  // 安装 sendBeacon hook
+  _KKJSBridgeSendBeaconHook.setupHook();
 
   // 安装 ajax hook
   _KKJSBridgeXHR.setupHook();

--- a/KKJSBridge/TS/src/indexold.ts
+++ b/KKJSBridge/TS/src/indexold.ts
@@ -5,6 +5,7 @@ import { KKJSBridge } from "./bridge/KKJSBridge"
 import { _KKJSBridgeFormData } from "./hook/KKJSBridgeFormDataHook"
 import { _KKJSBridgeCOOKIE } from "./hook/KKJSBridgeCookieHook"
 import { _KKJSBridgeXHR } from "./hook/KKJSBridgeAjaxHook"
+import { _KKJSBridgeSendBeaconHook } from "./hook/KKJSBridgeSendBeaconHook"
 
 var init = function() {
   if (window.KKJSBridge) {
@@ -75,6 +76,9 @@ var init = function() {
 
   // 安装 cookie hook
   _KKJSBridgeCOOKIE.setupHook();
+
+  // 安装 sendBeacon hook
+  _KKJSBridgeSendBeaconHook.setupHook();
 
   // 安装 ajax hook
   _KKJSBridgeXHR.setupHook();


### PR DESCRIPTION
你好，感谢你的这套方案。
我们在使用过程中发现这套方案并不支持发 sendBeacon 的请求，使用 navigator.sendBeacon 的时候依旧会丢 body（我们的跳出率统计 sdk 会使用 SendBeacon，因为它能够保证用户关闭 webview 窗口之后也能发起请求）。
因此我们基于你们的方案增加了对 navigator.sendBeacon 的支持。

另外因为希望 sendBeacon 能够与 ajaxHook 共用一个 body 处理方法，免得维护困难，我们对原来的功能做了一点点重构。
https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon